### PR TITLE
EndOfLine Tab Fix

### DIFF
--- a/libvcs4j-api/src/main/java/de/unibremen/informatik/st/libvcs4j/VCSFile.java
+++ b/libvcs4j-api/src/main/java/de/unibremen/informatik/st/libvcs4j/VCSFile.java
@@ -377,8 +377,14 @@ public interface VCSFile extends VCSModelElement {
 		public Position endOfLine() throws IOException {
 			final List<String> lines = getFile().readLines();
 			Validate.validateState(lines.size() >= getLine());
-			final int lastColumn = lines.get(getLine() - 1).length();
-			return getFile().positionOf(getLine(), lastColumn, getTabSize())
+			final String currentLine = lines.get(getLine()-1);
+			int column = 1;
+			for(char c : currentLine.toCharArray()){
+				column = c == '\t'
+						? ( (column-1)/getTabSize() + 1 ) * getTabSize() + 1
+						: column + 1;
+			}
+			return getFile().positionOf(getLine(), column, getTabSize())
 					.orElseThrow(IllegalStateException::new);
 		}
 

--- a/libvcs4j-api/src/main/java/de/unibremen/informatik/st/libvcs4j/VCSFile.java
+++ b/libvcs4j-api/src/main/java/de/unibremen/informatik/st/libvcs4j/VCSFile.java
@@ -379,10 +379,13 @@ public interface VCSFile extends VCSModelElement {
 			Validate.validateState(lines.size() >= getLine());
 			final String currentLine = lines.get(getLine()-1);
 			int column = 1;
-			for(char c : currentLine.toCharArray()){
-				column = c == '\t'
-						? ( (column-1)/getTabSize() + 1 ) * getTabSize() + 1
-						: column + 1;
+			if(!currentLine.isEmpty()) {
+				for (char c : currentLine.toCharArray()) {
+					column = c == '\t'
+							? ((column - 1) / getTabSize() + 1) * getTabSize() + 1
+							: column + 1;
+				}
+				column--;
 			}
 			return getFile().positionOf(getLine(), column, getTabSize())
 					.orElseThrow(IllegalStateException::new);

--- a/libvcs4j-api/src/main/java/de/unibremen/informatik/st/libvcs4j/VCSFile.java
+++ b/libvcs4j-api/src/main/java/de/unibremen/informatik/st/libvcs4j/VCSFile.java
@@ -379,14 +379,12 @@ public interface VCSFile extends VCSModelElement {
 			Validate.validateState(lines.size() >= getLine());
 			final String currentLine = lines.get(getLine()-1);
 			int column = 1;
-			if(!currentLine.isEmpty()) {
-				for (char c : currentLine.toCharArray()) {
-					column = c == '\t'
-							? ((column - 1) / getTabSize() + 1) * getTabSize() + 1
-							: column + 1;
-				}
-				column--;
+			for (char c : currentLine.toCharArray()) {
+				column = c == '\t'
+						? ((column - 1) / getTabSize() + 1) * getTabSize() + 1
+						: column + 1;
 			}
+			column--;
 			return getFile().positionOf(getLine(), column, getTabSize())
 					.orElseThrow(IllegalStateException::new);
 		}

--- a/libvcs4j-api/src/test/java/de/unibremen/informatik/st/libvcs4j/PositionTest.java
+++ b/libvcs4j-api/src/test/java/de/unibremen/informatik/st/libvcs4j/PositionTest.java
@@ -159,6 +159,24 @@ public class PositionTest {
 		assertThat(endOfLine.getTabSize()).isEqualTo(7);
 		assertThat(endOfLine.getOffset()).isEqualTo(20);
 		assertThat(endOfLine.getLineOffset()).isEqualTo(20);
+
+		lines = Collections.singletonList(
+				"\t\t\t} else {");
+
+		VCSFile file2 = mock(VCSFile.class);
+		when(file2.readLines()).thenReturn(lines);
+		when(file2.readLinesWithEOL()).thenReturn(lines);
+		when(file2.positionOf(1, 9, 4)).thenCallRealMethod();
+		when(file2.positionOf(1, 20, 4)).thenCallRealMethod();
+
+		VCSFile.Position position2 = file.positionOf(1, 9, 4)
+				.orElseThrow(AssertionError::new);
+		VCSFile.Position endOfLine2 = position.endOfLine();
+		assertThat(endOfLine2.getLine()).isEqualTo(1);
+		assertThat(endOfLine2.getColumn()).isEqualTo(20);
+		assertThat(endOfLine2.getTabSize()).isEqualTo(4);
+		assertThat(endOfLine2.getOffset()).isEqualTo(19);
+		assertThat(endOfLine2.getLineOffset()).isEqualTo(19);
 	}
 
 	@Test

--- a/libvcs4j-api/src/test/java/de/unibremen/informatik/st/libvcs4j/PositionTest.java
+++ b/libvcs4j-api/src/test/java/de/unibremen/informatik/st/libvcs4j/PositionTest.java
@@ -166,17 +166,17 @@ public class PositionTest {
 		VCSFile file2 = mock(VCSFile.class);
 		when(file2.readLines()).thenReturn(lines);
 		when(file2.readLinesWithEOL()).thenReturn(lines);
-		when(file2.positionOf(1, 9, 4)).thenCallRealMethod();
+		when(file2.positionOf(1, 1, 4)).thenCallRealMethod();
 		when(file2.positionOf(1, 20, 4)).thenCallRealMethod();
 
-		VCSFile.Position position2 = file.positionOf(1, 9, 4)
+		VCSFile.Position position2 = file2.positionOf(1, 1, 4)
 				.orElseThrow(AssertionError::new);
-		VCSFile.Position endOfLine2 = position.endOfLine();
+		VCSFile.Position endOfLine2 = position2.endOfLine();
 		assertThat(endOfLine2.getLine()).isEqualTo(1);
 		assertThat(endOfLine2.getColumn()).isEqualTo(20);
 		assertThat(endOfLine2.getTabSize()).isEqualTo(4);
-		assertThat(endOfLine2.getOffset()).isEqualTo(19);
-		assertThat(endOfLine2.getLineOffset()).isEqualTo(19);
+		assertThat(endOfLine2.getOffset()).isEqualTo(10);
+		assertThat(endOfLine2.getLineOffset()).isEqualTo(10);
 	}
 
 	@Test

--- a/libvcs4j-api/src/test/java/de/unibremen/informatik/st/libvcs4j/PositionTest.java
+++ b/libvcs4j-api/src/test/java/de/unibremen/informatik/st/libvcs4j/PositionTest.java
@@ -160,23 +160,29 @@ public class PositionTest {
 		assertThat(endOfLine.getOffset()).isEqualTo(20);
 		assertThat(endOfLine.getLineOffset()).isEqualTo(20);
 
-		lines = Collections.singletonList(
+
+	}
+
+	@Test
+	public void endOfLineWithTabs() throws IOException {
+
+		List<String> lines = Collections.singletonList(
 				"\t\t\t} else {");
 
-		VCSFile file2 = mock(VCSFile.class);
-		when(file2.readLines()).thenReturn(lines);
-		when(file2.readLinesWithEOL()).thenReturn(lines);
-		when(file2.positionOf(1, 1, 4)).thenCallRealMethod();
-		when(file2.positionOf(1, 20, 4)).thenCallRealMethod();
+		VCSFile file = mock(VCSFile.class);
+		when(file.readLines()).thenReturn(lines);
+		when(file.readLinesWithEOL()).thenReturn(lines);
+		when(file.positionOf(1, 1, 4)).thenCallRealMethod();
+		when(file.positionOf(1, 20, 4)).thenCallRealMethod();
 
-		VCSFile.Position position2 = file2.positionOf(1, 1, 4)
+		VCSFile.Position position = file.positionOf(1, 1, 4)
 				.orElseThrow(AssertionError::new);
-		VCSFile.Position endOfLine2 = position2.endOfLine();
-		assertThat(endOfLine2.getLine()).isEqualTo(1);
-		assertThat(endOfLine2.getColumn()).isEqualTo(20);
-		assertThat(endOfLine2.getTabSize()).isEqualTo(4);
-		assertThat(endOfLine2.getOffset()).isEqualTo(10);
-		assertThat(endOfLine2.getLineOffset()).isEqualTo(10);
+		VCSFile.Position endOfLine = position.endOfLine();
+		assertThat(endOfLine.getLine()).isEqualTo(1);
+		assertThat(endOfLine.getColumn()).isEqualTo(20);
+		assertThat(endOfLine.getTabSize()).isEqualTo(4);
+		assertThat(endOfLine.getOffset()).isEqualTo(10);
+		assertThat(endOfLine.getLineOffset()).isEqualTo(10);
 	}
 
 	@Test


### PR DESCRIPTION
Fixes a bug in the endOfLine() method of the VCSFile.Position class that resulted in wrong column data due to not properly counting tab characters.